### PR TITLE
MOD allow FnxSelect to be nullable

### DIFF
--- a/lib/src/components/select/fnx_select.dart
+++ b/lib/src/components/select/fnx_select.dart
@@ -22,6 +22,7 @@ class FnxSelect extends FnxInputComponent implements ControlValueAccessor, OnIni
   @Input() bool neverShowFilter = false;
   @Input() bool alwaysShowFilter = false;
   @Input() bool readonly = false;
+  @Input() bool nullable = false;
 
   List<FnxOptionValue> options = [];
 
@@ -154,7 +155,7 @@ class FnxSelect extends FnxInputComponent implements ControlValueAccessor, OnIni
       toggleSelectedOption(value);
     } else {
       if (this.value == value) {
-        // _value = null; asi ne
+        if (nullable) this.value = null;
       } else {
         this.value = value;
       }


### PR DESCRIPTION
Nullable selects will have their values reset to null when clicked on already selected value

Solves #9: introduces attribute `nullable` which when clicked on already selected option will reset the value of the select to `null`

Signed-off-by: Jiří Zůna <jiri@zunovi.cz>